### PR TITLE
fix: incorrect bucket selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@debridge-finance/dln-client": "3.5.0",
+        "@debridge-finance/dln-client": "3.6.2",
         "@debridge-finance/solana-utils": "2.0.0",
         "@protobuf-ts/plugin": "2.8.1",
         "@solana/web3.js": "1.66.2",
@@ -639,9 +639,9 @@
       "integrity": "sha512-MA93NzDNhgI5KzpMFuenWp5Qfm13q1fkuvge903Kg9/o1JcDgL0coH2Nf0I0OZctqlGC3d34wj3ABQzCaB8KAw=="
     },
     "node_modules/@debridge-finance/dln-client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-3.5.0.tgz",
-      "integrity": "sha512-vEuAMkeHYec0++kWcAz42ctCjOMDJ2ew2Rt93SJ0R1afqv9L2qa+SrI/CPc2DhpxFd4YOvQo5w8ca6GzzVPkxA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-3.6.2.tgz",
+      "integrity": "sha512-m11u5Eva2gU36RAXtB7GmOcEath8Tb3//KNLKcAB7nD48oubNWds/XdOFP6+hPpZ1ap8vkwcCGx4Q9WYYsPpHA==",
       "dependencies": {
         "@debridge-finance/solana-contracts-client": "2.3.0",
         "@debridge-finance/solana-transaction-parser": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "tslint-plugin-prettier": "2.3.0"
   },
   "dependencies": {
-    "@debridge-finance/dln-client": "3.5.0",
+    "@debridge-finance/dln-client": "3.6.2",
     "@debridge-finance/solana-utils": "2.0.0",
     "@protobuf-ts/plugin": "2.8.1",
     "@solana/web3.js": "1.66.2",

--- a/src/processors/universal.ts
+++ b/src/processors/universal.ts
@@ -6,16 +6,19 @@ import {
   ClientError,
   evm,
   EvmChains,
+  findExpectedBucket,
   getEngineByChainId,
   OrderData,
   OrderState,
-  pickReserveToken,
   PreswapFulfillOrderPayload,
   tokenAddressToString,
   tokenStringToBuffer,
   ZERO_EVM_ADDRESS,
 } from "@debridge-finance/dln-client";
-import { SwapConnectorRequest, SwapConnectorResult } from "@debridge-finance/dln-client/dist/types/swapConnector/swap.connector";
+import {
+  SwapConnectorRequest,
+  SwapConnectorResult
+} from "@debridge-finance/dln-client/dist/types/swapConnector/swap.connector";
 import BigNumber from "bignumber.js";
 import { Logger } from "pino";
 import Web3 from "web3";
@@ -25,12 +28,7 @@ import { createClientLogger } from "../logger";
 import { EvmProviderAdapter, Tx } from "../providers/evm.provider.adapter";
 import { SolanaProviderAdapter } from "../providers/solana.provider.adapter";
 
-import {
-  BaseOrderProcessor,
-  OrderProcessorContext,
-  OrderProcessorInitContext,
-  OrderProcessorInitializer,
-} from "./base";
+import { BaseOrderProcessor, OrderProcessorContext, OrderProcessorInitContext, OrderProcessorInitializer } from "./base";
 import { BatchUnlocker } from "./BatchUnlocker";
 import { MempoolService } from "./mempool.service";
 import { approveToken } from "./utils/approve";
@@ -382,7 +380,7 @@ class UniversalProcessor extends BaseOrderProcessor {
     }
 
     // perform rough estimation: assuming order.give.amount is what we need on balance
-    const pickedBucket = pickReserveToken(orderInfo.order, context.config.buckets);
+    const pickedBucket = findExpectedBucket(orderInfo.order, context.config.buckets);
     const [reserveSrcTokenDecimals, reserveDstTokenDecimals] = await Promise.all([
       context.config.client.getDecimals(orderInfo.order.give.chainId, pickedBucket.reserveSrcToken, context.giveChain.fulfillProvider.connection as Web3),
       context.config.client.getDecimals(orderInfo.order.take.chainId, pickedBucket.reserveDstToken, this.takeChain.fulfillProvider.connection as Web3),


### PR DESCRIPTION
During order estimation, the dln-taker has been picking the bucket using recommendation algorithm, which is used upon order creation and is allowed to pick arbitrary bucket regardless of give token. This caused some orders to stuck because picket bucket's selected token was not the same as order's give token: for example, for the order `0x831fc3ddc5b96eb1717a110bee45a2f4d71f6dcfc4e0b623305e286ecebfbef4` (USDC -> ETH) the ETH bucket was chosen, though the USDC bucket has been expected to be picked. 

This PR switches dln-taker to use another algorithm of bucket selection, which is suitable for order estimation.

Only dln-ts-client v3.6.2 exposes this algorithm. 
