### PR TITLE
feat: update dln-ts-client to v3.6.3 with half slippage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@debridge-finance/dln-executor",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-executor",
-      "version": "2.1.0",
+      "version": "2.1.2",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@debridge-finance/dln-client": "3.6.2",
+        "@debridge-finance/dln-client": "3.6.3",
         "@debridge-finance/solana-utils": "2.0.0",
         "@protobuf-ts/plugin": "2.8.1",
         "@solana/web3.js": "1.66.2",
@@ -639,9 +639,9 @@
       "integrity": "sha512-MA93NzDNhgI5KzpMFuenWp5Qfm13q1fkuvge903Kg9/o1JcDgL0coH2Nf0I0OZctqlGC3d34wj3ABQzCaB8KAw=="
     },
     "node_modules/@debridge-finance/dln-client": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-3.6.2.tgz",
-      "integrity": "sha512-m11u5Eva2gU36RAXtB7GmOcEath8Tb3//KNLKcAB7nD48oubNWds/XdOFP6+hPpZ1ap8vkwcCGx4Q9WYYsPpHA==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-3.6.3.tgz",
+      "integrity": "sha512-7NlAzqGwdNPAFOBtkA/bFVP5V8u/3HO8OCWD6s1zLktPRyVzTCFQ3fr0sFuRNz9GNJsezEyVixa2/KT7/vBMmw==",
       "dependencies": {
         "@debridge-finance/solana-contracts-client": "2.3.0",
         "@debridge-finance/solana-transaction-parser": "1.1.1",
@@ -6043,9 +6043,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.365",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.365.tgz",
-      "integrity": "sha512-FRHZO+1tUNO4TOPXmlxetkoaIY8uwHzd1kKopK/Gx2SKn1L47wJXWD44wxP5CGRyyP98z/c8e1eBzJrgPeiBOg=="
+      "version": "1.4.368",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.368.tgz",
+      "integrity": "sha512-e2aeCAixCj9M7nJxdB/wDjO6mbYX+lJJxSJCXDzlr5YPGYVofuJwGN9nKg2o6wWInjX6XmxRinn3AeJMK81ltw=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -10501,11 +10501,11 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.3.tgz",
-      "integrity": "sha512-P8ur/gp/AmbEzjr729bZnLjXK5Z+4P0zhIJgBgzqRih7hL7BOukHGtSTA3ACMY467GRFz3duQsi0bDZdR7DKdw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dependencies": {
-        "is-core-module": "^2.12.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@debridge-finance/dln-executor",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "author": "deBridge",
   "license": "GPL-3.0-only",
   "homepage": "https://debridge.finance",
@@ -39,7 +39,7 @@
     "tslint-plugin-prettier": "2.3.0"
   },
   "dependencies": {
-    "@debridge-finance/dln-client": "3.6.2",
+    "@debridge-finance/dln-client": "3.6.3",
     "@debridge-finance/solana-utils": "2.0.0",
     "@protobuf-ts/plugin": "2.8.1",
     "@solana/web3.js": "1.66.2",


### PR DESCRIPTION
This PR updates dln-ts-client to v3.6.3, where order estimation algorithm slightly changed and uses only half of the calculated slippage during order profitability estimation.

No BC breaks.