### PR TITLE
chore: update dln-ts-client to 4.0.3 (disable PMMs from 1inch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@debridge-finance/dln-executor",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-executor",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@debridge-finance/dln-client": "3.6.3",
+        "@debridge-finance/dln-client": "4.0.3",
         "@debridge-finance/solana-utils": "2.0.0",
         "@protobuf-ts/plugin": "2.8.1",
         "@solana/web3.js": "1.66.2",
@@ -639,9 +639,9 @@
       "integrity": "sha512-MA93NzDNhgI5KzpMFuenWp5Qfm13q1fkuvge903Kg9/o1JcDgL0coH2Nf0I0OZctqlGC3d34wj3ABQzCaB8KAw=="
     },
     "node_modules/@debridge-finance/dln-client": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-3.6.3.tgz",
-      "integrity": "sha512-7NlAzqGwdNPAFOBtkA/bFVP5V8u/3HO8OCWD6s1zLktPRyVzTCFQ3fr0sFuRNz9GNJsezEyVixa2/KT7/vBMmw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-4.0.3.tgz",
+      "integrity": "sha512-h9tEMbiXmXhzmj0iYEI0Y2jNTIwQJ5DEU4Qr2rMM26MJqOcPt9hJzfZcd41yAw0Pb6BF59xXW9Esv0UXT88oTg==",
       "dependencies": {
         "@debridge-finance/solana-contracts-client": "2.3.0",
         "@debridge-finance/solana-transaction-parser": "1.1.1",
@@ -6043,9 +6043,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.368",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.368.tgz",
-      "integrity": "sha512-e2aeCAixCj9M7nJxdB/wDjO6mbYX+lJJxSJCXDzlr5YPGYVofuJwGN9nKg2o6wWInjX6XmxRinn3AeJMK81ltw=="
+      "version": "1.4.369",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.369.tgz",
+      "integrity": "sha512-LfxbHXdA/S+qyoTEA4EbhxGjrxx7WK2h6yb5K2v0UCOufUKX+VZaHbl3svlzZfv9sGseym/g3Ne4DpsgRULmqg=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@debridge-finance/dln-executor",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "deBridge",
   "license": "GPL-3.0-only",
   "homepage": "https://debridge.finance",
@@ -39,7 +39,7 @@
     "tslint-plugin-prettier": "2.3.0"
   },
   "dependencies": {
-    "@debridge-finance/dln-client": "3.6.3",
+    "@debridge-finance/dln-client": "4.0.3",
     "@debridge-finance/solana-utils": "2.0.0",
     "@protobuf-ts/plugin": "2.8.1",
     "@solana/web3.js": "1.66.2",


### PR DESCRIPTION
This PR updates dln-ts-client to https://github.com/debridge-finance/dln-ts-client/releases/tag/v4.0.3, which allows disabling PMM protocols when querying swap txns from 1inch

Task-id: DEV-2616