### PR TITLE
feat: disable slippage buffer reservation when estimating pre-fullfil swap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-executor",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -9,7 +9,7 @@
       "version": "2.2.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@debridge-finance/dln-client": "4.0.3",
+        "@debridge-finance/dln-client": "4.0.5",
         "@debridge-finance/solana-utils": "2.0.0",
         "@protobuf-ts/plugin": "2.8.1",
         "@solana/web3.js": "1.66.2",
@@ -639,9 +639,9 @@
       "integrity": "sha512-MA93NzDNhgI5KzpMFuenWp5Qfm13q1fkuvge903Kg9/o1JcDgL0coH2Nf0I0OZctqlGC3d34wj3ABQzCaB8KAw=="
     },
     "node_modules/@debridge-finance/dln-client": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-4.0.3.tgz",
-      "integrity": "sha512-h9tEMbiXmXhzmj0iYEI0Y2jNTIwQJ5DEU4Qr2rMM26MJqOcPt9hJzfZcd41yAw0Pb6BF59xXW9Esv0UXT88oTg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-4.0.5.tgz",
+      "integrity": "sha512-MmV4MPfsyjZnranqC98BJE3xp/2aawZKoWOhuBPEHAxnUZsYbQU6s2qlwI+f/hj+iDvgeAV7bTzNNuDcwlZlaw==",
       "dependencies": {
         "@debridge-finance/solana-contracts-client": "2.3.0",
         "@debridge-finance/solana-transaction-parser": "1.1.1",
@@ -3318,11 +3318,11 @@
       }
     },
     "node_modules/@protobuf-ts/plugin-framework": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin-framework/-/plugin-framework-2.8.3.tgz",
-      "integrity": "sha512-VfQP5Cfipaf7XASz+VRdKshN8EuDDvbfp+c5RTS6c3utUn6KhylDQWKSR/J1+hS5bQ2rHqYTqf6zya8Wn/2o3w==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin-framework/-/plugin-framework-2.9.0.tgz",
+      "integrity": "sha512-/fgpwEgYeiazEpkp9S+iaxVXd6LCkfd2iCfsvHiiSz94DatwZGkhv/85ciq2vcZVwSeEagKoSKeinnQWYvTnxw==",
       "dependencies": {
-        "@protobuf-ts/runtime": "^2.8.3",
+        "@protobuf-ts/runtime": "^2.9.0",
         "typescript": "^3.9"
       }
     },
@@ -3351,24 +3351,24 @@
       }
     },
     "node_modules/@protobuf-ts/protoc": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.8.3.tgz",
-      "integrity": "sha512-j5REioDr7KT/cyfBD6k+FNkQFzkqv38PuUw+BsQ0dcIFJqaP8PnilbwtPn6kAJtI5QxFWPkoAr3fsWtjK7k6tQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.9.0.tgz",
+      "integrity": "sha512-8mQmw+OVqrpaHgmErle8heE5Z1ktX2vmWJmvFORSTcHxMfqHLv8RKTRroC9pkBQRgUaSGSXmy7n4ItdZnz41dw==",
       "bin": {
         "protoc": "protoc.js"
       }
     },
     "node_modules/@protobuf-ts/runtime": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.8.3.tgz",
-      "integrity": "sha512-nVL1s5wWpF6U+wtWTEWfUPD9Ockckj+fHqhzgm41CKV4Oma3D/2M6tzqOQ+wrm4GZu1bt+s6f43feNnar6fhjA=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.0.tgz",
+      "integrity": "sha512-DnJtLZFMglADv9jiawBmg0RaET4a6fNSAaAHuU6Ovw2ZhJ23ehIY0NrlYLS0Lc8HRH0S5rkLI1QF1A1h8uKUnA=="
     },
     "node_modules/@protobuf-ts/runtime-rpc": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.8.3.tgz",
-      "integrity": "sha512-Tb6nuevgezjGNnT8WF+aveGWeI5xeAbNpySd/nzknKx6ynepXdlNz5cN0xIADeOgDJHo/05Ka+vZ5ZI33tz2Og==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.0.tgz",
+      "integrity": "sha512-h2S86+u2cNJACjzbBubbjKmNrnXkTmJ9yJHW4t7ZVS9xdV1C68blsVIh3Su4ghR8Nlj0459FuIUTsjWR8hA/7g==",
       "dependencies": {
-        "@protobuf-ts/runtime": "^2.8.3"
+        "@protobuf-ts/runtime": "^2.9.0"
       }
     },
     "node_modules/@scure/base": {
@@ -3447,13 +3447,13 @@
       ]
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.49.0.tgz",
-      "integrity": "sha512-ESh3+ZneQk/3HESTUmIPNrW5GVPu/HrRJU+eAJJto74vm+6vP7zDn2YV2gJ1w18O/37nc7W/bVCgZJlhZ3cwew==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.50.0.tgz",
+      "integrity": "sha512-4TQ4vN0aMBWsUXfJWk2xbe4x7fKfwCXgXKTtHC/ocwwKM+0EefV5Iw9YFG8IrIQN4vMtuRzktqcs9q0/Sbv7tg==",
       "dependencies": {
-        "@sentry/core": "7.49.0",
-        "@sentry/types": "7.49.0",
-        "@sentry/utils": "7.49.0",
+        "@sentry/core": "7.50.0",
+        "@sentry/types": "7.50.0",
+        "@sentry/utils": "7.50.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3466,12 +3466,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/core": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.49.0.tgz",
-      "integrity": "sha512-AlSnCYgfEbvK8pkNluUkmdW/cD9UpvOVCa+ERQswXNRkAv5aDGCL6Ihv6fnIajE++BYuwZh0+HwZUBVKTFzoZg==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.50.0.tgz",
+      "integrity": "sha512-6oD1a3fYs4aiNK7tuJSd88LHjYJAetd7ZK/AfJniU7zWKj4jxIYfO8nhm0qdnhEDs81RcweVDmPhWm3Kwrzzsg==",
       "dependencies": {
-        "@sentry/types": "7.49.0",
-        "@sentry/utils": "7.49.0",
+        "@sentry/types": "7.50.0",
+        "@sentry/utils": "7.50.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -3484,14 +3484,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.49.0.tgz",
-      "integrity": "sha512-KLIrqcbKk4yR3g8fjl87Eyv4M9j4YI6b7sqVAZYj3FrX3mC6JQyGdlDfUpSKy604n1iAdr6OuUp5f9x7jPJaeQ==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.50.0.tgz",
+      "integrity": "sha512-11UJBKoQFMp7f8sbzeO2gENsKIUkVCNBTzuPRib7l2K1HMjSfacXmwwma7ZEs0mc3ofIZ1UYuyONAXmI1lK9cQ==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.49.0",
-        "@sentry/core": "7.49.0",
-        "@sentry/types": "7.49.0",
-        "@sentry/utils": "7.49.0",
+        "@sentry-internal/tracing": "7.50.0",
+        "@sentry/core": "7.50.0",
+        "@sentry/types": "7.50.0",
+        "@sentry/utils": "7.50.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -3507,19 +3507,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/types": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.49.0.tgz",
-      "integrity": "sha512-9yXXh7iv76+O6h2ONUVx0wsL1auqJFWez62mTjWk4350SgMmWp/zUkBxnVXhmcYqscz/CepC+Loz9vITLXtgxg==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.50.0.tgz",
+      "integrity": "sha512-Zo9vyI98QNeYT0K0y57Rb4JRWDaPEgmp+QkQ4CRQZFUTWetO5fvPZ4Gb/R7TW16LajuHZlbJBHmvmNj2pkL2kw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.49.0.tgz",
-      "integrity": "sha512-JdC9yGnOgev4ISJVwmIoFsk8Zx0psDZJAj2DV7x4wMZsO6QK+YjC7G3mUED/S5D5lsrkBZ/3uvQQhr8DQI4UcQ==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.50.0.tgz",
+      "integrity": "sha512-iyPwwC6fwJsiPhH27ZbIiSsY5RaccHBqADS2zEjgKYhmP4P9WGgHRDrvLEnkOjqQyKNb6c0yfmv83n0uxYnolw==",
       "dependencies": {
-        "@sentry/types": "7.49.0",
+        "@sentry/types": "7.50.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -6043,9 +6043,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.369",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.369.tgz",
-      "integrity": "sha512-LfxbHXdA/S+qyoTEA4EbhxGjrxx7WK2h6yb5K2v0UCOufUKX+VZaHbl3svlzZfv9sGseym/g3Ne4DpsgRULmqg=="
+      "version": "1.4.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.376.tgz",
+      "integrity": "sha512-TFeOKd98TpJzRHkr4Aorn16QkMnuCQuGAE6IZ0wYF+qkbSfMPqjplvRppR02tMUpVxZz8nyBNvVm9lIZsqrbPQ=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -8547,9 +8547,9 @@
       "dev": true
     },
     "node_modules/joi": {
-      "version": "17.9.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.1.tgz",
-      "integrity": "sha512-FariIi9j6QODKATGBrEX7HZcja8Bsh3rfdGYy/Sb65sGlZWK/QWesU1ghk7aJWDj95knjXlQfSmzFSPPkLVsfw==",
+      "version": "17.9.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
+      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -10642,9 +10642,9 @@
       "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@debridge-finance/dln-executor",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": "deBridge",
   "license": "GPL-3.0-only",
   "homepage": "https://debridge.finance",
@@ -39,7 +39,7 @@
     "tslint-plugin-prettier": "2.3.0"
   },
   "dependencies": {
-    "@debridge-finance/dln-client": "4.0.3",
+    "@debridge-finance/dln-client": "4.0.5",
     "@debridge-finance/solana-utils": "2.0.0",
     "@protobuf-ts/plugin": "2.8.1",
     "@solana/web3.js": "1.66.2",

--- a/src/executors/executor.ts
+++ b/src/executors/executor.ts
@@ -6,6 +6,7 @@ import {
   OneInchConnector,
   PMMClient,
   PriceTokenService,
+  setSlippageOverloader,
   Solana,
   SwapConnector,
   SwapConnectorImpl,
@@ -292,6 +293,9 @@ export class Executor implements IExecutor {
       points: chain.usdAmountConfirmations.map(t => t.minBlockConfirmations)
     }))
     orderFeed.init(this.execute.bind(this), unlockAuthorities, minConfirmationThresholds, hooksEngine);
+
+    // Override internal slippage calculation: do not reserve slippage buffer for pre-fulfill swap
+    setSlippageOverloader(() => 0);
 
     this.isInitialized = true;
   }

--- a/src/processors/BatchUnlocker.ts
+++ b/src/processors/BatchUnlocker.ts
@@ -89,7 +89,7 @@ export class BatchUnlocker {
     return this.addOrder(orderId, order, context);
   }
 
-  async addOrder(
+  private async addOrder(
     orderId: string,
     order: OrderData,
     context: OrderProcessorContext) {


### PR DESCRIPTION
This PR updates dln-client to https://github.com/debridge-finance/dln-ts-client/releases/tag/v4.0.5.

With this update:
- slippage buffer is not reserved upon estimating pre-fulfill swap from the `reserveToken` to `takeToken`, relying on the given outcome
- minAmount for pre-fulfill swap is calculated as a ratio between estimated outcome (`evaluatedTakeAmount`) and the requested `takeAmount`, but not less than 5bps or more than 3bps
- pre-fulfill swap refund are sent to the taker's address

Task ID: DEV-2684