### PR TITLE
feature: customGiveMinProfitabilityBps for order processor

### DIFF
--- a/debridge.config.ts
+++ b/debridge.config.ts
@@ -49,6 +49,9 @@ const config: ExecutorLaunchConfig = {
 
   orderProcessor: processors.universalProcessor({
     minProfitabilityBps: 4,
+    customGiveMinProfitabilityBps: {
+      [ChainId.Fantom]: 300,
+    }
   }),
 
   chains: [

--- a/sample.config.ts
+++ b/sample.config.ts
@@ -67,6 +67,11 @@ const config: ExecutorLaunchConfig = {
     // assuming that the order would be unlocked in a batch of size=10. Reducing the batch size to a lower value increases
     // your unlock costs and thus reduces order profitability, making them unprofitable most of the time.
     batchUnlockSize: 10,
+
+    //The profitability that should be used for order created in configured chain instead of minProfitabilityBps
+    customGiveMinProfitabilityBps: {
+      [ChainId.Fantom]: 300,
+    }
   }),
 
   chains: [
@@ -128,10 +133,6 @@ const config: ExecutorLaunchConfig = {
       beneficiary: `${process.env.FANTOM_BENEFICIARY}`,
       takerPrivateKey: `${process.env.FANTOM_TAKER_PRIVATE_KEY}`,
       unlockAuthorityPrivateKey: `${process.env.FANTOM_UNLOCK_AUTHORITY_PRIVATE_KEY}`,
-
-      orderProcessor: processors.universalProcessor({
-        minProfitabilityBps: 300,
-      }),
     },
 
     {


### PR DESCRIPTION
**What's Changed**

- option to configure customGiveMinProfitabilityBps in order processor
- fantom minProfitabilityBps is 300

customGiveMinProfitabilityBps is a dictionary that contains profitabilities that should be used for order created in configured chain instead of minProfitabilityBps