### PR TITLE
feature: pre-fulfill swap's change recipient

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 - Grab the source code:
 ```sh
-git clone --depth 1 --single-branch --branch v2.5-latest git@github.com:debridge-finance/dln-taker.git
+git clone --depth 1 --single-branch --branch v2.6-latest git@github.com:debridge-finance/dln-taker.git
 ```
 - `cd` to the directory and install necessary production dependencies:
 ```sh
@@ -62,10 +62,10 @@ From the high level perspective, `dln-taker` automates the process of order esti
 
 ## Installation
 
-Fetch the source code from Github, picking the given revision (current: `v2.5-latest`):
+Fetch the source code from Github, picking the given revision (current: `v2.6-latest`):
 
 ```sh
-git clone --depth 1 --single-branch --branch v2.5-latest git@github.com:debridge-finance/dln-taker.git
+git clone --depth 1 --single-branch --branch v2.6-latest git@github.com:debridge-finance/dln-taker.git
 ```
 
 `cd` to the directory and install necessary production dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debridge-finance/dln-executor",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-executor",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "5.2.0",
@@ -6497,9 +6497,9 @@
       }
     },
     "node_modules/pino-std-serializers": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.1.tgz",
-      "integrity": "sha512-wHuWB+CvSVb2XqXM0W/WOYUkVSPbiJb9S5fNB7TBhd8s892Xq910bRxwHtC4l71hgztObTjXL6ZheZXFjhDrDQ=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@debridge-finance/dln-executor",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "author": "deBridge",
   "license": "GPL-3.0-only",
   "homepage": "https://debridge.finance",

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,12 @@ export type DstOrderConstraints = {
      * coming to this chain after it first saw it.
      */
     fulfillmentDelay?: number;
+
+    /**
+     * Defines a target where pre-fulfill swap change should be send to. Default: "taker".
+     * Warning: applies to EVM chains only
+     */
+    preFulfillSwapChangeRecipient?: "taker" | "maker";
 }
 
 export type SrcOrderConstraints = {

--- a/src/executors/executor.ts
+++ b/src/executors/executor.ts
@@ -51,6 +51,7 @@ export type ExecutorInitializingChain = Readonly<{
 
 type DstOrderConstraints = Readonly<{
   fulfillmentDelay: number;
+  preFulfillSwapChangeRecipient: "taker" | "maker";
 }>
 
 type DstConstraintsPerOrderValue = Array<
@@ -339,7 +340,8 @@ export class Executor implements IExecutor {
 
   private getDstConstraints(primaryConstraints: RawDstOrderConstraints, defaultConstraints?: RawDstOrderConstraints): DstOrderConstraints {
     return {
-      fulfillmentDelay: primaryConstraints?.fulfillmentDelay || defaultConstraints?.fulfillmentDelay || 0
+      fulfillmentDelay: primaryConstraints?.fulfillmentDelay || defaultConstraints?.fulfillmentDelay || 0,
+      preFulfillSwapChangeRecipient: primaryConstraints?.preFulfillSwapChangeRecipient || defaultConstraints?.preFulfillSwapChangeRecipient || "taker"
     }
   }
 

--- a/src/processors/universal.ts
+++ b/src/processors/universal.ts
@@ -791,7 +791,10 @@ while calculateExpectedTakeAmount returned ${tokenAddressToString(orderInfo.orde
         web3: this.takeChain.fulfillProvider.connection as Web3,
         permit: "0x",
         takerAddress: this.takeChain.fulfillProvider.address,
-        unlockAuthority: this.takeChain.unlockProvider.address
+        unlockAuthority: this.takeChain.unlockProvider.address,
+        swapRefundReceiverAddress: context.takeChain.dstConstraints.preFulfillSwapChangeRecipient == "taker"
+          ? this.takeChain.fulfillProvider.address
+          : tokenAddressToString(this.chainId, order.orderAuthorityDstAddress)
       };
       fullFillTxPayload = evmfullFillTxPayload;
     }


### PR DESCRIPTION
This PR introduces new `dstConstraints.preFulfillSwapChangeRecipient` property which is able to set where the change of a possible pre-fulfill swap should be transferred to. Possible values:
- `maker`: the change would be transferred to maker defined as orders' `orderAuthorityDstAddress`
- `taker`: the change would be transferred back to the taker 