### PR TITLE
fix: reject orders that require pre-fulfill swaps where swaps are not available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debridge-finance/dln-executor",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-executor",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "5.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@debridge-finance/dln-executor",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "author": "deBridge",
   "license": "GPL-3.0-only",
   "homepage": "https://debridge.finance",

--- a/sample.config.ts
+++ b/sample.config.ts
@@ -29,6 +29,7 @@ const config: ExecutorLaunchConfig = {
       [ChainId.Avalanche]: ["0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"],
       [ChainId.BSC]: ["0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d"],
       [ChainId.Ethereum]: ["0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"],
+      [ChainId.Linea]: ['0x176211869cA2b568f2A7D4EE941E073a821EE1ff'],
       [ChainId.Optimism]: ['0x7f5c764cbc14f9669b88837ca1490cca17c31607'],
       [ChainId.Polygon]: ["0x2791bca1f2de4661ed88a30c99a7a9449aa84174"],
       [ChainId.Solana]: ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"],

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,11 @@ export enum SupportedChain {
   Optimism = ChainId.Optimism,
 }
 
+export enum DexlessChains {
+  Base = ChainId.Base,
+  Linea = ChainId.Linea,
+}
+
 export class EvmRebroadcastAdapterOpts {
   /**
    * defines a multiplier to increase a pending txn's gasPrice for pushing it off the mempool.

--- a/src/configurator/tokenPriceService.ts
+++ b/src/configurator/tokenPriceService.ts
@@ -24,6 +24,12 @@ export function tokenPriceService(opts?: TokenPriceServiceConfiguratorOpts): Pri
                 chainId: ChainId.Ethereum,
                 token: tokenStringToBuffer(ChainId.Ethereum, ZERO_EVM_ADDRESS),
               },
+              // remap USDC@Linea price to USDC@Ethereum
+              '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': {
+                type: 'redirect',
+                chainId: ChainId.Ethereum,
+                token: tokenStringToBuffer(ChainId.Ethereum, '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'),
+              },
             },
             [ChainId.Base]: {
               // remap ETH@Base price to ETH@Ethereum

--- a/src/hooks/HookEnums.ts
+++ b/src/hooks/HookEnums.ts
@@ -97,4 +97,10 @@ export enum RejectionReason {
    * indicates that non-finalized order is not covered by any custom block confirmation range
    */
   NOT_YET_FINALIZED,
+
+  /**
+   * indicates that the order requires reserve token to be pre-swapped to the take token, but the operation can't be
+   * performed because swaps are not available on the take chain
+   */
+  UNAVAILABLE_PRE_FULFILL_SWAP,
 }


### PR DESCRIPTION
This PR introduces a small fix that prevents the script from attempting to estimate orders that require pre-fulfill swaps where such swaps are not yet available (e.g., on Linea or Base). 

This PR also adds `USDC` to the list of sample buckets