### PR TITLE
fix: evm address initialization didn't use predefined overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debridge-finance/dln-executor",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-executor",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "5.8.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@debridge-finance/dln-executor",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "author": "deBridge",
   "license": "GPL-3.0-only",
   "homepage": "https://debridge.finance",

--- a/src/executors/executor.ts
+++ b/src/executors/executor.ts
@@ -146,16 +146,16 @@ export class Executor implements IExecutor {
               PRODUCTION.chains[chain.chain]?.pmmSrc,
             pmmDestinationAddress:
               chain.environment?.pmmDst ||
-              PRODUCTION.defaultEvmAddresses?.pmmDst ||
-              PRODUCTION.chains[chain.chain]?.pmmDst,
+              PRODUCTION.chains[chain.chain]?.pmmDst ||
+              PRODUCTION.defaultEvmAddresses?.pmmDst,
             deBridgeGateAddress:
               chain.environment?.deBridgeContract ||
-              PRODUCTION.defaultEvmAddresses?.deBridgeContract ||
-              PRODUCTION.chains[chain.chain]?.deBridgeContract,
+              PRODUCTION.chains[chain.chain]?.deBridgeContract ||
+              PRODUCTION.defaultEvmAddresses?.deBridgeContract,
             crossChainForwarderAddress:
               chain.environment?.evm?.forwarderContract ||
-              PRODUCTION.defaultEvmAddresses?.evm?.forwarderContract ||
-              PRODUCTION.chains[chain.chain]?.evm?.forwarderContract,
+              PRODUCTION.chains[chain.chain]?.evm?.forwarderContract ||
+              PRODUCTION.defaultEvmAddresses?.evm?.forwarderContract
           };
         }
       }


### PR DESCRIPTION
This PR fixes a bug in address initialization picker: custom predefined addresses were not respected during chain initialization, which may lead to using default addresses instead. This caused Optimism chain to use default `CrosschainForwarder` address instead of custom one.