### PR TITLE
fix: TVLBudget may have been overestimated

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ constraints: {
 ### Setting a TVL budget
 
 It is now possible to define a budget (priced in the US dollar) of assets deployed and locked on the given chain. This
-allows to limit the risks of having to much liquidity on a particular chain, which is the case when a lof of orders
+allows to limit the risks of having too much liquidity on a particular chain, which is the case when a lof of orders
 are coming from such chain during a turmoil.
 
 Any new order coming from the given chain to any other supported chain that potentially increases the TVL beyond
@@ -212,7 +212,7 @@ a re-balancing routines, or automatically when orders coming to this chain get f
 The TVL is calculated as a sum of:
 - the total value of intermediary assets deployed on the taker account (represented as `takerPrivateKey`)
 - PLUS the total value of intermediary assets deployed on the unlock_beneficiary account (represented
-  as `unlockAuthorityPrivateKey`, if differs from `takerPrivateKey`)
+  as `beneficiary` address, if differs from the address resolved from the `takerPrivateKey`)
 - PLUS the total value of intermediary assets locked by the DLN smart contract that yet to be transferred to
   the unlock_beneficiary account as soon as the commands to unlock fulfilled (but not yet unlocked) orders
   are sent from other chains

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debridge-finance/dln-executor",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-executor",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@debridge-finance/dln-executor",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "author": "deBridge",
   "license": "GPL-3.0-only",
   "homepage": "https://debridge.finance",

--- a/src/processors/TVLBudgetController.ts
+++ b/src/processors/TVLBudgetController.ts
@@ -37,7 +37,7 @@ export class TVLBudgetController {
   }
 
   get hasSeparateUnlockBeneficiary(): boolean {
-    return !buffersAreEqual(this.giveChain.fulfillProvider.bytesAddress, this.giveChain.unlockProvider.bytesAddress)
+    return !buffersAreEqual(this.giveChain.fulfillProvider.bytesAddress, this.giveChain.beneficiary)
   }
 
   get trackedTokens(): Address[] {
@@ -77,7 +77,7 @@ export class TVLBudgetController {
 
   private async getUnlockBeneficiaryAccountBalance(): Promise<number> {
     if (!this.hasSeparateUnlockBeneficiary) return 0;
-    return this.getAccountValue(this.giveChain.unlockProvider.bytesAddress);
+    return this.getAccountValue(this.giveChain.beneficiary);
   }
 
   private async getAccountValue(account: Address): Promise<number> {


### PR DESCRIPTION
This PR fixes a small bug introduced by #92 were `unlock_authority` account (intended to initiate unlocking procedures to the given chain) has been erroneously used as `unlock_beneficiary` (intended to receive funds from the orders being successfully unlocked).

https://app.clickup.com/t/4717986/DEV-2892