### PR TITLE
fix: use lowered block confirmations when checking order status from Solana

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debridge-finance/dln-executor",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-executor",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "6.5.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@debridge-finance/dln-executor",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "author": "deBridge",
   "license": "GPL-3.0-only",
   "homepage": "https://debridge.finance",

--- a/src/processors/universal.ts
+++ b/src/processors/universal.ts
@@ -477,7 +477,9 @@ class UniversalProcessor extends BaseOrderProcessor {
         orderId: orderInfo.orderId,
         giveChain: orderInfo.order.give.chainId,
       },
-      {}
+      {
+        confirmationsCount: confirmationFloor
+      }
     );
 
     if (giveOrderStatus?.status === undefined) {


### PR DESCRIPTION
This PR fixes a bug that may cause non-finalized orders coming from Solana to be not seen by the executor. This bug was caused by #93 

Task ID: https://app.clickup.com/t/862kank6w