### PR TITLE
fix: processor configured from config has been ignored

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
   "license": "GPL-3.0-only",
   "author": "deBridge",

--- a/src/executors/executor.ts
+++ b/src/executors/executor.ts
@@ -380,7 +380,8 @@ export class Executor implements IExecutor {
         }
       }
 
-      const processorInitializer = processors.universalProcessor();
+      const processorInitializer =
+        chain.orderProcessor || config.orderProcessor || processors.universalProcessor();
       const initializingChain = {
         chain: chain.chain,
         chainRpc: chain.chainRpc,


### PR DESCRIPTION
This PR fixes bug introduced in #113, that is causing processor configured in the config.ts (incl. custom profitability and batch size) to be ignored

Task ID: https://app.clickup.com/t/862kcg4hk