### PR TITLE
fix: order processing for zero take amount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-taker",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "7.0.2",
-        "@debridge-finance/legacy-dln-profitability": "1.3.2",
+        "@debridge-finance/legacy-dln-profitability": "1.3.5",
         "@debridge-finance/solana-utils": "4.1.0",
         "@protobuf-ts/plugin": "2.8.1",
         "@solana/web3.js": "1.66.2",
@@ -571,9 +571,9 @@
       "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
     },
     "node_modules/@debridge-finance/legacy-dln-profitability": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@debridge-finance/legacy-dln-profitability/-/legacy-dln-profitability-1.3.2.tgz",
-      "integrity": "sha512-RG15d9jXLfMDjBF0DPjZ+rMedXY3EsciSK3SOUrZ4aeg0luEjM3zwPHqdRft9QBTF+cXmplwLtUHMMncbEnsJw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@debridge-finance/legacy-dln-profitability/-/legacy-dln-profitability-1.3.5.tgz",
+      "integrity": "sha512-W0JYTXi+Ba/VmhYwp0v9LIR14KfDjXaBM8WO9v5gB4DuWOLsVFlUlcY3aCciKu1snT6SsvLo6wQ+BA6m1J0EpQ==",
       "dependencies": {
         "@debridge-finance/dln-client": "^7.0.0",
         "node-cache": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
   "license": "GPL-3.0-only",
   "author": "deBridge",
@@ -33,7 +33,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@debridge-finance/dln-client": "7.0.2",
-    "@debridge-finance/legacy-dln-profitability": "1.3.2",
+    "@debridge-finance/legacy-dln-profitability": "1.3.5",
     "@debridge-finance/solana-utils": "4.1.0",
     "@protobuf-ts/plugin": "2.8.1",
     "@solana/web3.js": "1.66.2",

--- a/src/processors/universal.ts
+++ b/src/processors/universal.ts
@@ -765,10 +765,13 @@ class UniversalProcessor extends BaseOrderProcessor {
       if (new BigNumber(requiredReserveDstAmount).isEqualTo('0')) {
         message = 'not enough give amount to cover operating expenses';
       } else {
-        const takeAmountDrop = new BigNumber(profitableTakeAmount)
-          .multipliedBy(100)
-          .div(orderInfo.order.take.amount.toString());
-        const takeAmountDropShare = BigNumber(100).minus(takeAmountDrop).toFixed(2);
+        let takeAmountDropShare: string = '100';
+        if (orderInfo.order.take.amount !== 0n) {
+          const takeAmountDrop = new BigNumber(profitableTakeAmount)
+            .multipliedBy(100)
+            .div(orderInfo.order.take.amount.toString());
+          takeAmountDropShare = BigNumber(100).minus(takeAmountDrop).toFixed(2);
+        }
 
         const reserveTokenDesc = tokenAddressToString(this.takeChain.chain, reserveDstToken);
         const takeTokenDesc = tokenAddressToString(
@@ -915,8 +918,11 @@ class UniversalProcessor extends BaseOrderProcessor {
   }
 
   private getPreFulfillSlippage(evaluatedTakeAmount: bigint, takeAmount: bigint): number {
-    const calculatedSlippageBps =
-      ((evaluatedTakeAmount - takeAmount) * BigInt(BPS_DENOMINATOR)) / evaluatedTakeAmount;
+    let calculatedSlippageBps: bigint = 10_000n;
+    if (takeAmount !== 0n) {
+      calculatedSlippageBps =
+        ((evaluatedTakeAmount - takeAmount) * BigInt(BPS_DENOMINATOR)) / evaluatedTakeAmount;
+    }
     if (calculatedSlippageBps < this.params.preFulfillSwapMinAllowedSlippageBps)
       return this.params.preFulfillSwapMinAllowedSlippageBps;
     if (calculatedSlippageBps > this.params.preFulfillSwapMaxAllowedSlippageBps)


### PR DESCRIPTION
What's changed

* fixed profitable detection for order with zero take amount(updated @debridge-finance/legacy-dln-profitability)
* fixed postponed message for is not profitable event for order with zero take amount
* fixed preswap slippage calculation  for order with zero take amount

Task: https://app.clickup.com/t/4717986/DEV-3272