### PR TITLE
feat: multiply evm tx gas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-taker",
-      "version": "2.15.6",
+      "version": "2.15.7",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
   "license": "GPL-3.0-only",
   "author": "deBridge",


### PR DESCRIPTION
This PR multiplies EVM txn gas by 1.05 to reduce chances of being out of gas (which is often a case in Avalanche C-chain). Multiplication is done in cost of reduced gasPrice multiplier