### PR TITLE
fix: make expenses as 0 when value less than 5%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "8.2.1",
-        "@debridge-finance/legacy-dln-profitability": "2.1.0",
+        "@debridge-finance/legacy-dln-profitability": "2.1.2",
         "@debridge-finance/solana-utils": "4.2.1",
         "@protobuf-ts/plugin": "2.8.1",
         "@solana/web3.js": "1.66.2",
@@ -628,9 +628,9 @@
       "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
     },
     "node_modules/@debridge-finance/legacy-dln-profitability": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@debridge-finance/legacy-dln-profitability/-/legacy-dln-profitability-2.1.0.tgz",
-      "integrity": "sha512-hs9etgebFx75AkcZQ/X/krXQEtvK8tRrBbG9rZVJtX7WiB8ySXXT8keL6ZxUGW0r00+fttDm6YBkViGk86/Emw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@debridge-finance/legacy-dln-profitability/-/legacy-dln-profitability-2.1.2.tgz",
+      "integrity": "sha512-7boU74BedSA4pL+CZwqfiWsAJoghOmJeRrVcDq9tvsZj35fpcqZze5JsKjz+pTlUoFWT1xP6aRR9KVDOuOIgdw==",
       "dependencies": {
         "@debridge-finance/dln-client": "^8.1.0",
         "node-cache": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@debridge-finance/dln-client": "8.2.1",
-    "@debridge-finance/legacy-dln-profitability": "2.1.0",
+    "@debridge-finance/legacy-dln-profitability": "2.1.2",
     "@debridge-finance/solana-utils": "4.2.1",
     "@protobuf-ts/plugin": "2.8.1",
     "@solana/web3.js": "1.66.2",


### PR DESCRIPTION
What's changed?

* make expenses as 0 for order with take chain optimism in case when expenses less then 5%

Task: https://app.clickup.com/t/4717986/DEV-3833