### PR TITLE
update legacy-dln-profitability to reflect OP Horizon constraints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-taker",
-      "version": "2.16.3",
+      "version": "2.16.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "8.2.1",
-        "@debridge-finance/legacy-dln-profitability": "2.1.2",
+        "@debridge-finance/legacy-dln-profitability": "2.1.3",
         "@debridge-finance/solana-utils": "4.2.1",
         "@protobuf-ts/plugin": "2.8.1",
         "@solana/web3.js": "1.66.2",
@@ -310,11 +310,11 @@
       }
     },
     "node_modules/@coral-xyz/anchor/node_modules/@solana/web3.js": {
-      "version": "1.87.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.2.tgz",
-      "integrity": "sha512-TZNhS+tvJbYjm0LAvIkUy/3Aqgt2l6/3X6XsVUpvj5MGOl2Q6Ch8hYSxcUUtMbAFNN3sUXmV8NhhMLNJEvI6TA==",
+      "version": "1.87.3",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.3.tgz",
+      "integrity": "sha512-WGLzTZpi00vP443qGK3gL+LZXQJwaWkh6bzNXYpMTCAH2Z102y3YbPWOoQzJUeRSZWSXKh7MFkA3vDMFlMvGZQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.23.2",
         "@noble/curves": "^1.2.0",
         "@noble/hashes": "^1.3.1",
         "@solana/buffer-layout": "^4.0.0",
@@ -452,11 +452,11 @@
       }
     },
     "node_modules/@coral-xyz/spl-token/node_modules/@solana/web3.js": {
-      "version": "1.87.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.2.tgz",
-      "integrity": "sha512-TZNhS+tvJbYjm0LAvIkUy/3Aqgt2l6/3X6XsVUpvj5MGOl2Q6Ch8hYSxcUUtMbAFNN3sUXmV8NhhMLNJEvI6TA==",
+      "version": "1.87.3",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.3.tgz",
+      "integrity": "sha512-WGLzTZpi00vP443qGK3gL+LZXQJwaWkh6bzNXYpMTCAH2Z102y3YbPWOoQzJUeRSZWSXKh7MFkA3vDMFlMvGZQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.23.2",
         "@noble/curves": "^1.2.0",
         "@noble/hashes": "^1.3.1",
         "@solana/buffer-layout": "^4.0.0",
@@ -628,9 +628,9 @@
       "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
     },
     "node_modules/@debridge-finance/legacy-dln-profitability": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@debridge-finance/legacy-dln-profitability/-/legacy-dln-profitability-2.1.2.tgz",
-      "integrity": "sha512-7boU74BedSA4pL+CZwqfiWsAJoghOmJeRrVcDq9tvsZj35fpcqZze5JsKjz+pTlUoFWT1xP6aRR9KVDOuOIgdw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@debridge-finance/legacy-dln-profitability/-/legacy-dln-profitability-2.1.3.tgz",
+      "integrity": "sha512-Nrd2Xy4+ygc2lbKJOt6j9XJPQsZgzTGnGFRYrIK0z9blnaYoXUHt/lDGHkGrRjk0iGhb3QDfdOeOXljlPAohbw==",
       "dependencies": {
         "@debridge-finance/dln-client": "^8.1.0",
         "node-cache": "5.1.2",
@@ -1115,11 +1115,11 @@
       }
     },
     "node_modules/@debridge-finance/solana-contracts-client/node_modules/@solana/web3.js": {
-      "version": "1.87.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.2.tgz",
-      "integrity": "sha512-TZNhS+tvJbYjm0LAvIkUy/3Aqgt2l6/3X6XsVUpvj5MGOl2Q6Ch8hYSxcUUtMbAFNN3sUXmV8NhhMLNJEvI6TA==",
+      "version": "1.87.3",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.3.tgz",
+      "integrity": "sha512-WGLzTZpi00vP443qGK3gL+LZXQJwaWkh6bzNXYpMTCAH2Z102y3YbPWOoQzJUeRSZWSXKh7MFkA3vDMFlMvGZQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.23.2",
         "@noble/curves": "^1.2.0",
         "@noble/hashes": "^1.3.1",
         "@solana/buffer-layout": "^4.0.0",
@@ -1272,11 +1272,11 @@
       }
     },
     "node_modules/@debridge-finance/solana-transaction-parser/node_modules/@solana/web3.js": {
-      "version": "1.87.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.2.tgz",
-      "integrity": "sha512-TZNhS+tvJbYjm0LAvIkUy/3Aqgt2l6/3X6XsVUpvj5MGOl2Q6Ch8hYSxcUUtMbAFNN3sUXmV8NhhMLNJEvI6TA==",
+      "version": "1.87.3",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.3.tgz",
+      "integrity": "sha512-WGLzTZpi00vP443qGK3gL+LZXQJwaWkh6bzNXYpMTCAH2Z102y3YbPWOoQzJUeRSZWSXKh7MFkA3vDMFlMvGZQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.23.2",
         "@noble/curves": "^1.2.0",
         "@noble/hashes": "^1.3.1",
         "@solana/buffer-layout": "^4.0.0",
@@ -1380,11 +1380,11 @@
       }
     },
     "node_modules/@debridge-finance/solana-utils/node_modules/@solana/web3.js": {
-      "version": "1.87.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.2.tgz",
-      "integrity": "sha512-TZNhS+tvJbYjm0LAvIkUy/3Aqgt2l6/3X6XsVUpvj5MGOl2Q6Ch8hYSxcUUtMbAFNN3sUXmV8NhhMLNJEvI6TA==",
+      "version": "1.87.3",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.3.tgz",
+      "integrity": "sha512-WGLzTZpi00vP443qGK3gL+LZXQJwaWkh6bzNXYpMTCAH2Z102y3YbPWOoQzJUeRSZWSXKh7MFkA3vDMFlMvGZQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.23.2",
         "@noble/curves": "^1.2.0",
         "@noble/hashes": "^1.3.1",
         "@solana/buffer-layout": "^4.0.0",
@@ -2812,9 +2812,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2834,9 +2834,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
+      "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
   "license": "GPL-3.0-only",
   "author": "deBridge",
@@ -33,7 +33,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@debridge-finance/dln-client": "8.2.1",
-    "@debridge-finance/legacy-dln-profitability": "2.1.2",
+    "@debridge-finance/legacy-dln-profitability": "2.1.3",
     "@debridge-finance/solana-utils": "4.2.1",
     "@protobuf-ts/plugin": "2.8.1",
     "@solana/web3.js": "1.66.2",


### PR DESCRIPTION
This update reflects a new requirement: https://github.com/debridge-finance/legacy-dln-profitability/pull/16

Follows #148 