### PR TITLE
Update dln ts client v8.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-taker",
-      "version": "2.17.0",
+      "version": "2.17.1",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@debridge-finance/dln-client": "8.2.7",
+        "@debridge-finance/dln-client": "8.3.1",
         "@debridge-finance/legacy-dln-profitability": "2.2.2",
         "@debridge-finance/solana-utils": "4.2.1",
         "@protobuf-ts/plugin": "2.8.1",
@@ -423,9 +423,9 @@
       "integrity": "sha512-MA93NzDNhgI5KzpMFuenWp5Qfm13q1fkuvge903Kg9/o1JcDgL0coH2Nf0I0OZctqlGC3d34wj3ABQzCaB8KAw=="
     },
     "node_modules/@debridge-finance/dln-client": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-8.2.7.tgz",
-      "integrity": "sha512-yXOoA9rpBfer2vHeblHjQq4bgqKLa1Odhb0PSapzgmh8dA2ooQIgfRflaTYeRrzCo0EjJHc5kY6j48XNgFkVcA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@debridge-finance/dln-client/-/dln-client-8.3.1.tgz",
+      "integrity": "sha512-6Fw9/mynNKjIUgHZ6tlq3GEsUaLj9sZlYjDZzZFPRMSg+TCiQrZsqxAt13D4VdCurWSn/dGzFeH6g6Nea74cvQ==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@debridge-finance/debridge-external-call": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
   "license": "GPL-3.0-only",
   "author": "deBridge",
@@ -32,7 +32,7 @@
   },
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "@debridge-finance/dln-client": "8.2.7",
+    "@debridge-finance/dln-client": "8.3.1",
     "@debridge-finance/legacy-dln-profitability": "2.2.2",
     "@debridge-finance/solana-utils": "4.2.1",
     "@protobuf-ts/plugin": "2.8.1",


### PR DESCRIPTION
This PR updates dln-ts-client to fix case when `jupiterConfig.blacklistedDexes` is not set and requests to jup.ag API are failing