### PR TITLE
feature: order subsidization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-taker",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "8.3.3",
-        "@debridge-finance/legacy-dln-profitability": "2.2.2",
+        "@debridge-finance/legacy-dln-profitability": "3.2.0",
         "@debridge-finance/solana-utils": "4.2.1",
         "@protobuf-ts/plugin": "2.8.1",
         "@solana/web3.js": "1.66.2",
@@ -595,9 +595,9 @@
       }
     },
     "node_modules/@debridge-finance/legacy-dln-profitability": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@debridge-finance/legacy-dln-profitability/-/legacy-dln-profitability-2.2.2.tgz",
-      "integrity": "sha512-+tYDvg4QyIaX4aLDCDyVdjL/xtMvcI9x1Gs37KV+TkM/y2WCSIkJugJsvO7qCMjXR5lBguERUXDWQWf9fgJRIQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@debridge-finance/legacy-dln-profitability/-/legacy-dln-profitability-3.2.0.tgz",
+      "integrity": "sha512-yVyx5eQxBoNWj92p0uDurG2eFS/jdyOX5xjkhWPdUruP7XxV1XLewU8MLEEOgR7RRIpBUHx0F9ZVbFYBFMZyrw==",
       "dependencies": {
         "@debridge-finance/dln-client": "^8.1.0",
         "node-cache": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
   "license": "GPL-3.0-only",
   "author": "deBridge",
@@ -33,7 +33,7 @@
   "types": "./dist/index.d.ts",
   "dependencies": {
     "@debridge-finance/dln-client": "8.3.3",
-    "@debridge-finance/legacy-dln-profitability": "2.2.2",
+    "@debridge-finance/legacy-dln-profitability": "3.2.0",
     "@debridge-finance/solana-utils": "4.2.1",
     "@protobuf-ts/plugin": "2.8.1",
     "@solana/web3.js": "1.66.2",

--- a/sample.config.ts
+++ b/sample.config.ts
@@ -50,7 +50,32 @@ const config: ExecutorLaunchConfig = {
     },
   ],
 
+  /*
+  Example:
+  subsidizationRules: [{
+    giveChainIds: [ChainId.BSC],
+    takeChainIds: "any",
+    notTakeChainIds: [ChainId.Solana],
+    ranges: [
+      {
+        range: {
+          minUsdOrderValue: 1,
+          maxUsdOrderValue: 100,
+        },
+        usdSubsidy: 1,
+      },
+      {
+        range: {
+          minUsdOrderValue: 101,
+          maxUsdOrderValue: 1000,
+        },
+        usdSubsidy: 2,
+      }
+    ]
+  }],
+   */
   subsidizationRules: [],
+
   allowSubsidy: false,
 
   tokenPriceService: configurator.tokenPriceService({

--- a/sample.config.ts
+++ b/sample.config.ts
@@ -50,6 +50,9 @@ const config: ExecutorLaunchConfig = {
     },
   ],
 
+  subsidizationRules: [],
+  allowSubsidy: false,
+
   tokenPriceService: configurator.tokenPriceService({
     coingeckoApiKey: process?.env?.COINGECKO_API_KEY,
   }),

--- a/src/chain-common/order-estimator.ts
+++ b/src/chain-common/order-estimator.ts
@@ -113,6 +113,8 @@ export class OrderEstimator extends OrderEvaluationContextual {
       batchSize: this.order.giveChain.srcConstraints.batchUnlockSize,
       swapEstimationPreference: this.getRouteHint(),
       isFeatureEnableOpHorizon: process.env.DISABLE_OP_HORIZON_CAMPAIGN !== 'true',
+      allowSubsidy: this.order.executor.allowSubsidy,
+      subsidizationRules: this.order.executor.subsidizationRules,
     };
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { ChainId, PriceTokenService } from '@debridge-finance/dln-client';
 
+import { SubsidizationRule } from '@debridge-finance/legacy-dln-profitability';
 import { OrderFilterInitializer } from './filters/order.filter';
 import { GetNextOrder } from './interfaces';
 import { Hooks } from './hooks/HookEnums';
@@ -321,6 +322,17 @@ export interface ExecutorLaunchConfig {
    * Default: CoingeckoPriceFeed
    */
   tokenPriceService?: PriceTokenService;
+
+  /**
+   * Rule to subsidize orders
+   * Default: []
+   */
+  subsidizationRules?: SubsidizationRule[];
+
+  /**
+   * Default: false
+   */
+  allowSubsidy?: boolean;
 
   /**
    * Source of orders

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { ChainId } from '@debridge-finance/dln-client';
+import { SubsidizationRule } from '@debridge-finance/legacy-dln-profitability';
 import configurator from './configurator/index';
 import * as filters from './filters';
 import { ExecutorLaunchConfig } from './config';
@@ -22,6 +23,7 @@ export {
   configurator,
   filters,
   ExecutorLaunchConfig,
+  SubsidizationRule,
 
   // environment
   environments,


### PR DESCRIPTION
What's changed?

* allowSubsidy, subsidizationRules in config

When allowSubsidy is enabled, the module searches for the first suitable subsidy for the order, considering chain compatibility and values, then applies the found subsidy to reserveDstAmount if an appropriate range for USD_VALUE(order.give.amount) is identified.

Task: https://app.clickup.com/t/4717986/DEV-3968

See also: https://github.com/debridge-finance/legacy-dln-profitability/pull/22