### PR TITLE
fix: ignore accidental archival orders is corresponding  live orders are received

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-taker",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "8.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
   "license": "GPL-3.0-only",
   "author": "deBridge",


### PR DESCRIPTION
Sometimes WS pushes orders in `ArchivalCreated` status which undesirably override the schedule of live orders received earlier. This PR fixes this behaviour by effectively ignoring archival orders if corresponding live orders are already known by the taker instance.

TaskID: https://app.clickup.com/t/4717986/DEV-4164