### PR TITLE
feat: postpone orders missing in the give-chain rather then reject them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@debridge-finance/dln-taker",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@debridge-finance/dln-client": "8.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@debridge-finance/dln-taker",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "DLN executor is the rule-based daemon service developed to automatically execute orders placed on the deSwap Liquidity Network (DLN) across supported blockchains",
   "license": "GPL-3.0-only",
   "author": "deBridge",

--- a/src/chain-common/order-validator.ts
+++ b/src/chain-common/order-validator.ts
@@ -273,7 +273,7 @@ export class OrderValidator extends OrderEvaluationContextual {
 
     if (giveOrderStatus?.status === undefined) {
       const message = `order does not exist on the give chain (${ChainId[giveChainId]})`;
-      return this.sc.reject(RejectionReason.MISSING, message);
+      return this.sc.postpone(PostponingReason.MISSING, message);
     }
 
     if (giveOrderStatus?.status !== OrderState.Created) {

--- a/src/hooks/HookEnums.ts
+++ b/src/hooks/HookEnums.ts
@@ -49,6 +49,12 @@ export enum PostponingReason {
    * triggered when throughput has reached its limit for the given give chain
    */
   CAPPED_THROUGHPUT,
+
+  /**
+   * indicates that the order is missing on the give chain. One of the possible reasons is a lag in the RPC node, which
+   * is often the case when it comes to Solana
+   */
+  MISSING,
 }
 
 export enum RejectionReason {
@@ -66,12 +72,6 @@ export enum RejectionReason {
    * indicates that the order on the give chain has non-zero status (e.g., unlocked)
    */
   UNEXPECTED_GIVE_STATUS,
-
-  /**
-   * indicates that the order is missing on the give chain.
-   * This is extremely unlikely, and indicates protocol discrepancy if happens
-   */
-  MISSING,
 
   /**
    * indicates that the order is revoked due to chain reorg


### PR DESCRIPTION
This PR makes orders missing in the give-chain to be postponed instead of being rejected, because the RPC may have a lag that causes taker not to see the order being placed.

Task ID: https://app.clickup.com/t/4717986/DEV-4140